### PR TITLE
Allow failures when ATL not supported.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,15 @@ environment:
     - TOOLCHAIN: "vs-9-2008"
       PROJECT_DIR: examples\WTL
 
-    - TOOLCHAIN: "mingw"
+matrix:
+  allow_failures:
+    - TOOLCHAIN: "vs-9-2008"
+      PROJECT_DIR: examples\WTL
+
+    - TOOLCHAIN: "vs-10-2010"
+      PROJECT_DIR: examples\WTL
+
+    - TOOLCHAIN: "vs-11-2012"
       PROJECT_DIR: examples\WTL
 
 install:


### PR DESCRIPTION
Some of the tests have failed because WTL depends on ATL.  We can't
Hunterise ATL because it is part of the Visual Studio Compiler library
and has a proprietary license.

MinGW doesn't have ATL, so that build obviously fails.  However, some of
the VS builds are also failing because AppVeyor is using 'Express'
editions of Visual Studio, which also don't have ATL.

Apparently, the presence of WDK 7.1 is meant to work around this on
AppVeyor, but it's not being picked up.

This commit adds the Express builds to the set of allowed failures and
disables MinGW builds entirely.
