### PR TITLE
Disable tests for broken toolchains.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,13 @@ environment:
     - TOOLCHAIN: "nmake-vs-12-2013"
       PROJECT_DIR: examples\Expat
 
-    - TOOLCHAIN: "vs-10-2010"
-      PROJECT_DIR: examples\Expat
+    # Disable until Expat >2.1.1 is released containing fix for VS<12
+    # - TOOLCHAIN: "vs-10-2010"
+    #   PROJECT_DIR: examples\Expat
 
-    - TOOLCHAIN: "vs-11-2012"
-      PROJECT_DIR: examples\Expat
+    # Disable until Expat >2.1.1 is released containing fix for VS<12
+    # - TOOLCHAIN: "vs-11-2012"
+    #   PROJECT_DIR: examples\Expat
 
     - TOOLCHAIN: "vs-12-2013-win64"
       PROJECT_DIR: examples\Expat
@@ -37,8 +39,9 @@ environment:
     - TOOLCHAIN: "vs-14-2015"
       PROJECT_DIR: examples\Expat
 
-    - TOOLCHAIN: "vs-9-2008"
-      PROJECT_DIR: examples\Expat
+    # Disable until Expat >2.1.1 is released containing fix for VS<12
+    # - TOOLCHAIN: "vs-9-2008"
+    #   PROJECT_DIR: examples\Expat
 
     - TOOLCHAIN: "mingw"
       PROJECT_DIR: examples\Expat


### PR DESCRIPTION
VS < v12 2013 support only C90, but Expat broke C90 compatability in
2.1.1.  It is fixed upstream and the tests can be re-enabled when they
release a new version.  Until then, people who need to use older VS can
choose 2.1.0 in their config.
