### PR TITLE
Suppress broken android build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,10 @@ env:
     - PROJECT_DIR=examples/fmt TOOLCHAIN=osx-10-9
     - PROJECT_DIR=examples/fmt TOOLCHAIN=gcc-4-8
     - PROJECT_DIR=examples/fmt TOOLCHAIN=ios-nocodesign
-    - PROJECT_DIR=examples/fmt TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+    # FIXME:
+    # * https://travis-ci.org/ingenue/hunter/jobs/130544214
+    # lconv is stubbed on Android: https://github.com/fmtlib/fmt/issues/327
+    # - PROJECT_DIR=examples/fmt TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
     - PROJECT_DIR=examples/fmt TOOLCHAIN=analyze
     - PROJECT_DIR=examples/fmt TOOLCHAIN=sanitize-address
     - PROJECT_DIR=examples/fmt TOOLCHAIN=sanitize-leak


### PR DESCRIPTION
Suppressing android ARM build because of lconv issue:

```
/home/travis/build/ingenue/hunter/_testing/Hunter/_Base/c26ab45/894990f/8c15f91/Build/fmt/Source/fmt/format.h: In member function 'void fmt::BasicWriter<Char>::write_int(T, Spec)':
/home/travis/build/ingenue/hunter/_testing/Hunter/_Base/c26ab45/894990f/8c15f91/Build/fmt/Source/fmt/format.h:2756:45: error: 'struct lconv' has no member named 'thousands_sep'
     fmt::StringRef sep = std::localeconv()->thousands_sep;
                                             ^
```
