### PR TITLE
disables mingw and analyze builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ matrix:
       env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=gcc-4-8
     - os: linux
       env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
-    - os: linux
-      env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=analyze
+    #- os: linux
+    #  env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=analyze
     - os: linux
       env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=sanitize-address
     - os: linux
@@ -66,8 +66,8 @@ matrix:
       env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=ios-nocodesign
     - os: osx
       env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
-    - os: osx
-      env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=analyze
+    #- os: osx
+    #  env: PROJECT_DIR=examples/PocoCpp TOOLCHAIN=analyze
     # }
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,8 @@ environment:
     - TOOLCHAIN: "vs-9-2008"
       PROJECT_DIR: examples\PocoCpp
 
-    - TOOLCHAIN: "mingw"
-      PROJECT_DIR: examples\PocoCpp
+    #- TOOLCHAIN: "mingw"
+    #  PROJECT_DIR: examples\PocoCpp
 
 install:
   # Python 3


### PR DESCRIPTION
The mingw build is disabled, as it is not officially supported by POCO C++ Libraries. This is described in http://pocoproject.org/docs/99150-WindowsPlatformNotes.html.

Both analyze builds are also disabled.
