### PR TITLE
Updated OpenCL test package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,10 @@ matrix:
       env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=clang-libstdcxx
     - os: linux
       env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=gcc-4-8
-    - os: linux
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+#Android does not work with ICD, need to link against NDK
+#https://travis-ci.org/ingenue/hunter/jobs/180306953
+#    - os: linux
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
     - os: linux
       env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=analyze
     - os: linux
@@ -53,21 +55,29 @@ matrix:
       env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=sanitize-thread
     # }
 
-    # OSX {
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=default
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=libcxx
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=clang-libstdcxx
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=osx-10-11
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=ios-nocodesign-9-3
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
-    - os: osx
-      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=analyze
+    #Apple currently only supports OpenCL 1.2
+        # OSX {
+#https://travis-ci.org/ingenue/hunter/jobs/180306958
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=default
+#https://travis-ci.org/ingenue/hunter/jobs/180306959
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=libcxx
+#https://travis-ci.org/ingenue/hunter/jobs/180306960
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=clang-libstdcxx
+#https://travis-ci.org/ingenue/hunter/jobs/180306961
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=osx-10-11
+#https://travis-ci.org/ingenue/hunter/jobs/180306962
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=ios-nocodesign-9-3
+#https://travis-ci.org/ingenue/hunter/jobs/180306963
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
+#https://travis-ci.org/ingenue/hunter/jobs/180306964
+#    - os: osx
+#      env: PROJECT_DIR=examples/OpenCL TOOLCHAIN=analyze
     # }
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,11 +19,18 @@ environment:
     - TOOLCHAIN: "nmake-vs-12-2013"
       PROJECT_DIR: examples\OpenCL
 
-    - TOOLCHAIN: "vs-10-2010"
-      PROJECT_DIR: examples\OpenCL
-
-    - TOOLCHAIN: "vs-11-2012"
-      PROJECT_DIR: examples\OpenCL
+#VC 9-11 do not support some of the code used in the OpenCL headers
+#https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1206/job/ix590h5sb15m7yf3
+#    - TOOLCHAIN: "vs-9-2008"
+#      PROJECT_DIR: examples\OpenCL
+#
+#https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1206/job/8jmat42arvkfgayw
+#    - TOOLCHAIN: "vs-10-2010"
+#      PROJECT_DIR: examples\OpenCL
+#
+#https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1206/job/l3sbaotn6njmrimk
+#    - TOOLCHAIN: "vs-11-2012"
+#      PROJECT_DIR: examples\OpenCL
 
     - TOOLCHAIN: "vs-12-2013-win64"
       PROJECT_DIR: examples\OpenCL
@@ -37,11 +44,10 @@ environment:
     - TOOLCHAIN: "vs-14-2015"
       PROJECT_DIR: examples\OpenCL
 
-    - TOOLCHAIN: "vs-9-2008"
-      PROJECT_DIR: examples\OpenCL
-
-    - TOOLCHAIN: "mingw"
-      PROJECT_DIR: examples\OpenCL
+#this build links to native direct x which uses some VC specific code that gcc does not understand
+#https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1206/job/firtgemm7o3nhdsf
+#    - TOOLCHAIN: "mingw"
+#      PROJECT_DIR: examples\OpenCL
 
     - TOOLCHAIN: "msys"
       PROJECT_DIR: examples\OpenCL


### PR DESCRIPTION
Removed support for Android as it should be linked from the NDK.
Removed support for Apple as OpenCL support stops at 1.2
Removed VC 9-10 as the headers contain some code that they don't understand.
Removed MinGW on windows as it links to the native direct x which has some VC specific code that gcc does not understand.