### PR TITLE
Disable broken and unsupported toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ matrix:
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=gcc
     - os: linux
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
-    - os: linux
-      env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=analyze
+    # FIXME: Project does not compile with analyze toolchain
+    # * https://travis-ci.org/ingenue/hunter/jobs/229158997
+    # - os: linux
+    #   env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=analyze
     - os: linux
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=sanitize-address
     - os: linux
@@ -44,16 +46,22 @@ matrix:
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=default
     - os: osx
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=libcxx
-    - os: osx
-      env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=clang-libstdcxx
+    # Toolchain not supported by project (Requires c++ include initializer_list)
+    # * https://travis-ci.org/ingenue/hunter/jobs/229159004
+    # - os: osx
+    #   env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=clang-libstdcxx
     - os: osx
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=osx-10-11
-    - os: osx
-      env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=ios-nocodesign-9-3
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://travis-ci.org/ingenue/hunter/jobs/229159006
+    # - os: osx
+    #   env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=ios-nocodesign-9-3
     - os: osx
       env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
-    - os: osx
-      env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=analyze
+    # FIXME: Project does not compile with analyze toolchain
+    # * https://travis-ci.org/ingenue/hunter/jobs/229159008
+    # - os: osx
+    #   env: PROJECT_DIR=examples/CapnProto TOOLCHAIN=analyze
     # }
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,35 +10,53 @@ environment:
     - TOOLCHAIN: "default"
       PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "ninja-vs-12-2013-win64"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/x2xpx99qv97jmke8
+    # - TOOLCHAIN: "ninja-vs-12-2013-win64"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "nmake-vs-12-2013-win64"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/si3weggi8x1qk0u9
+    # - TOOLCHAIN: "nmake-vs-12-2013-win64"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "nmake-vs-12-2013"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/2px7t2nfkd2i0lby
+    # - TOOLCHAIN: "nmake-vs-12-2013"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-10-2010"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/x9pw33x0jtkn50i8
+    # - TOOLCHAIN: "vs-10-2010"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-11-2012"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/1f4dc0udv44oxit0
+    # - TOOLCHAIN: "vs-11-2012"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-12-2013-win64"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/qhschi9ewbn3x1l5
+    # - TOOLCHAIN: "vs-12-2013-win64"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-12-2013-xp"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/0jwvlg5lfcoxcq10
+    # - TOOLCHAIN: "vs-12-2013-xp"
+    #   PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-12-2013"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/ir0cjafkhan4o67v
+    # - TOOLCHAIN: "vs-12-2013"
+    #   PROJECT_DIR: examples\CapnProto
 
     - TOOLCHAIN: "vs-14-2015"
       PROJECT_DIR: examples\CapnProto
 
-    - TOOLCHAIN: "vs-9-2008"
-      PROJECT_DIR: examples\CapnProto
+    # Toolchain not supported by project (https://capnproto.org/install.html#supported-operating-systems)
+    # * https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1651/job/pcg0uiq2x131s120
+    # - TOOLCHAIN: "vs-9-2008"
+    #   PROJECT_DIR: examples\CapnProto
 
     - TOOLCHAIN: "mingw"
       PROJECT_DIR: examples\CapnProto


### PR DESCRIPTION

Interestingly, the build https://travis-ci.org/ingenue/hunter/jobs/229159004 with: 

`-- [polly] Used toolchain: clang / GNU Standard C++ Library (libstdc++) / c++11 support`
`-- The CXX compiler identification is AppleClang 7.3.0.7030031`

Reports: 
`-- Looking for C++ include initializer_list - not found`

While the build https://travis-ci.org/ingenue/hunter/jobs/229159006 with: 

`-- [polly] Used toolchain: iOS 9.3 Universal (iphoneos + iphonesimulator) / clang / No code sign / c++11 support`
`-- The CXX compiler identification is AppleClang 7.3.0.7030031`

Reports: 
`-- Looking for C++ include initializer_list - found`

Using same compiler and c++11 support but different results for C++ include initializer_list check.  Is this as expected? 
