### PR TITLE
glog: exclude tests for versions below vs-14-2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,29 +9,32 @@ environment:
   matrix:
     # Note: 'default' toolchain is the same as 'vs-14-2015'
 
-    - TOOLCHAIN: "ninja-vs-12-2013-win64"
-      PROJECT_DIR: examples\glog
+    # FIXME:
+    # * vs versions before vs-14-2015 fail with
+    #   "object with constructor or destructor cannot be declared 'thread'"
+    #- TOOLCHAIN: "ninja-vs-12-2013-win64"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "nmake-vs-12-2013-win64"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "nmake-vs-12-2013-win64"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "nmake-vs-12-2013"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "nmake-vs-12-2013"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "vs-10-2010"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "vs-10-2010"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "vs-11-2012"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "vs-11-2012"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "vs-12-2013-win64"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "vs-12-2013-win64"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "vs-12-2013-xp"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "vs-12-2013-xp"
+    #  PROJECT_DIR: examples\glog
 
-    - TOOLCHAIN: "vs-12-2013"
-      PROJECT_DIR: examples\glog
+    #- TOOLCHAIN: "vs-12-2013"
+    #  PROJECT_DIR: examples\glog
 
     - TOOLCHAIN: "vs-14-2015"
       PROJECT_DIR: examples\glog


### PR DESCRIPTION
- vs versions before vs-14-2015 fail with
  "object with constructor or destructor cannot be declared 'thread'"