### PR TITLE
Drop gcc-5 tests from OpenCV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,9 @@ matrix:
       env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=default
     - os: linux
       env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=clang-libstdcxx
-    - os: linux
-      env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=gcc-5 VERBOSE=0
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083573
+    # - os: linux
+    #   env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=gcc-5 VERBOSE=0
     - os: linux
       env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
     - os: linux
@@ -63,8 +64,9 @@ matrix:
     # Extra {
     - os: linux
       env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=gcc-pic
-    - os: linux
-      env: PROJECT_DIR=examples/OpenCV-Qt TOOLCHAIN=gcc-5 VERBOSE=0
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083580
+    # - os: linux
+    #   env: PROJECT_DIR=examples/OpenCV-Qt TOOLCHAIN=gcc-5 VERBOSE=0
     # }
 
     # }
@@ -100,8 +102,9 @@ matrix:
       env: PROJECT_DIR=examples/OpenCV-extra TOOLCHAIN=default
     - os: linux
       env: PROJECT_DIR=examples/OpenCV-extra TOOLCHAIN=clang-libstdcxx VERBOSE=0
-    - os: linux
-      env: PROJECT_DIR=examples/OpenCV-extra TOOLCHAIN=gcc-5
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083589
+    # - os: linux
+    #   env: PROJECT_DIR=examples/OpenCV-extra TOOLCHAIN=gcc-5
     - os: linux
       env: PROJECT_DIR=examples/OpenCV-extra TOOLCHAIN=gcc-pic
     - os: linux


### PR DESCRIPTION
Note: Cursory glance suggests that the AVX512 instructions included in 3.4.1 are broken on gcc-5.

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **Yes**
