### PR TITLE
Disabling 'analyse' due to dependency failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,13 @@ matrix:
       env: PROJECT_DIR=examples/WebP TOOLCHAIN=android-ndk-r10e-api-19-armeabi-v7a-neon
     - os: linux
       env: PROJECT_DIR=examples/WebP TOOLCHAIN=android-ndk-r15c-api-21-armeabi-v7a-neon-clang-libcxx
-    - os: linux
-      env: PROJECT_DIR=examples/WebP TOOLCHAIN=analyze
+      
+    # FIXME:
+    # * Fails due to dependency failure (see pkg.png)
+    # * https://travis-ci.org/ingenue/hunter/jobs/105845420
+    # - os: linux
+    #   env: PROJECT_DIR=examples/WebP TOOLCHAIN=analyze
+      
     - os: linux
       env: PROJECT_DIR=examples/WebP TOOLCHAIN=sanitize-address
     - os: linux


### PR DESCRIPTION
analyze currently fails on pkg.png, and was disabled as well.

https://github.com/ingenue/hunter/blob/pkg.png/.travis.yml#L45-L48

Will re-visit when pkg.png's analyze will be fixed.

<!--- Please check that your pull request satisfy all requirements -->

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes, but from another pkg responsible for the failure**
