### PR TITLE
replacing ios-nocodesign-10-3 to fix ios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,21 @@ matrix:
       env: PROJECT_DIR=examples/WebP TOOLCHAIN=libcxx
     - os: osx
       env: PROJECT_DIR=examples/WebP TOOLCHAIN=osx-10-12
+
+    # We cannot do iphoneos+iphonesimulator universal binary because the SIMD
+    # instruction set locks to neon for armv7 and arm64 cpu, and the simulator
+    # will fail since neon is unavailable on x86 and x64 cpu type.
+    #- os: osx
+    #  env: PROJECT_DIR=examples/WebP TOOLCHAIN=ios-nocodesign-10-3
+    
+    # Since we cannot do iphoneos+iphonesimulator universal binary, we can
+    # always build ios for individual cpu achitecture, so we are enabling
+    # both armv7 and arm64 ios build.
     - os: osx
-      env: PROJECT_DIR=examples/WebP TOOLCHAIN=ios-nocodesign-10-3
+      env: PROJECT_DIR=examples/WebP TOOLCHAIN=ios-nocodesign-10-3-armv7
+    - os: osx
+      env: PROJECT_DIR=examples/WebP TOOLCHAIN=ios-nocodesign-10-3-arm64
+      
     # }
 
 install:


### PR DESCRIPTION
<!--- Please check that your pull request satisfy all requirements -->

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes, but without CI build links. Just more info instead since the build failure is not obvious to understand what is going on at all**
