### PR TITLE
Remove broken toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,9 @@ matrix:
     # OSX {
     - os: osx
       env: PROJECT_DIR=examples/Libevent TOOLCHAIN=libcxx
-    - os: osx
-      env: PROJECT_DIR=examples/Libevent TOOLCHAIN=osx-10-11
+    # FIXME: https://travis-ci.org/isaachier/hunter/builds/357077343
+    # - os: osx
+    #   env: PROJECT_DIR=examples/Libevent TOOLCHAIN=osx-10-11
     # FIXME: https://travis-ci.org/ingenue/hunter/builds/276923018
     # - os: osx
     #   env: PROJECT_DIR=examples/Libevent TOOLCHAIN=ios-nocodesign-9-3


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **Yes**