### PR TITLE
 benchmark: enable some previously disabled toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,8 @@ matrix:
     - os: linux
       env: PROJECT_DIR=examples/benchmark TOOLCHAIN=gcc-7-cxx17
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/289681107
-    # - os: linux
-    #   env: PROJECT_DIR=examples/benchmark TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
+    - os: linux
+      env: PROJECT_DIR=examples/benchmark TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
 
     # FIXME: https://travis-ci.org/isaachier/hunter/builds/289681107
     # - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,9 @@ environment:
       TOOLCHAIN: "vs-14-2015-sdk-8-1"
       PROJECT_DIR: examples\benchmark
 
-    # FIXME: https://ci.appveyor.com/project/ingenue/hunter/build/1.0.2567
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #   TOOLCHAIN: "mingw-cxx17"
-    #   PROJECT_DIR: examples\benchmark
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      TOOLCHAIN: "mingw-cxx17"
+      PROJECT_DIR: examples\benchmark
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLCHAIN: "msys-cxx17"


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**
