### PR TITLE
APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,12 @@ matrix:
       env: PROJECT_DIR=examples/acf TOOLCHAIN=libcxx
     - os: osx
       env: PROJECT_DIR=examples/acf TOOLCHAIN=osx-10-12
+    # FIXME: Unknown error in testing (can't get meaningful log)
+    #- os: osx
+    #  env: PROJECT_DIR=examples/acf TOOLCHAIN=ios-nocodesign-10-3 VERBOSE=0
     - os: osx
-      env: PROJECT_DIR=examples/acf TOOLCHAIN=ios-nocodesign-10-3
+      osx_image: xcode9.2
+      env: PROJECT_DIR=examples/OpenCV TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-arm64 VERBOSE=0
     # }
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ environment:
     #   PROJECT_DIR: examples\acf
 
     - TOOLCHAIN: "vs-14-2015"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PROJECT_DIR: examples\acf
 
     # OpenCV dependency:


### PR DESCRIPTION
Add image specification.  This is probably optional but is required in my appveyor + hunter fork.  It should always work regardless of account defaults.

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **[Yes]**
