### PR TITLE
Tests for 'catkin' package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,23 +75,26 @@ matrix:
 
     # OSX {
 
-    - os: osx
-      osx_image: xcode9.3
-      env: >
-        TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/catkin
-
-    - os: osx
-      osx_image: xcode9.3
-      env: >
-        TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/catkin
-
-    - os: osx
-      osx_image: xcode9.3
-      env: >
-        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/catkin
+    # FIXME: OSX builds currently fail when installing `catkin_pkg` python package
+    #   * https://travis-ci.org/lsolanka/hunter/builds/366910484
+    #
+    # - os: osx
+    #   osx_image: xcode9.3
+    #   env: >
+    #     TOOLCHAIN=osx-10-13-make-cxx14
+    #     PROJECT_DIR=examples/catkin
+    #
+    # - os: osx
+    #   osx_image: xcode9.3
+    #   env: >
+    #     TOOLCHAIN=osx-10-13-cxx14
+    #     PROJECT_DIR=examples/catkin
+    #
+    # - os: osx
+    #   osx_image: xcode9.3
+    #   env: >
+    #     TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+    #     PROJECT_DIR=examples/catkin
 
     # }
 
@@ -113,7 +116,8 @@ install:
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
 
   # Install python packages required to build ROS components
-  - if [[ "`uname`" == "Darwin" ]]; then pip install catkin_pkg; fi
+  # FIXME: the following command fails with a 'Permission denied' error
+  # - if [[ "`uname`" == "Darwin" ]]; then pip install catkin_pkg; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     packages:
       - python3-pip
       - g++-7
+      - python-empy
 
 dist:
   - trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,26 +75,23 @@ matrix:
 
     # OSX {
 
-    # FIXME: OSX builds currently fail when installing `catkin_pkg` python package
-    #   * https://travis-ci.org/lsolanka/hunter/builds/366910484
-    #
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=osx-10-13-make-cxx14
-    #     PROJECT_DIR=examples/catkin
-    #
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=osx-10-13-cxx14
-    #     PROJECT_DIR=examples/catkin
-    #
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-    #     PROJECT_DIR=examples/catkin
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=osx-10-13-make-cxx14
+        PROJECT_DIR=examples/catkin
+
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=osx-10-13-cxx14
+        PROJECT_DIR=examples/catkin
+
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+        PROJECT_DIR=examples/catkin
 
     # }
 
@@ -116,8 +113,7 @@ install:
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
 
   # Install python packages required to build ROS components
-  # FIXME: the following command fails with a 'Permission denied' error
-  # - if [[ "`uname`" == "Darwin" ]]; then pip install catkin_pkg; fi
+  - if [[ "`uname`" == "Darwin" ]]; then pip install --user catkin_pkg; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,37 +37,37 @@ matrix:
     - os: linux
       env: >
         TOOLCHAIN=clang-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=gcc-7-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-address-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-leak-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-thread-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     # }
 
@@ -77,19 +77,19 @@ matrix:
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/catkin
 
     # }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     packages:
       - python3-pip
       - g++-7
+      - python-pip
       - python-empy
 
 dist:
@@ -112,8 +113,8 @@ install:
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
 
   # Install python packages required to build ROS components
-  - if [[ "`uname`" == "Darwin" ]]; then pip3 install catkin_pkg; fi
-  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user catkin_pkg; fi
+  - if [[ "`uname`" == "Darwin" ]]; then pip install catkin_pkg; fi
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ install:
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
 
   # Install python packages required to build ROS components
-  - if [[ "`uname`" == "Darwin" ]]; then pip install --user catkin_pkg; fi
+  - if [[ "`uname`" == "Darwin" ]]; then pip install --user empy catkin_pkg; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,10 @@ install:
   - if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
 
+  # Install python packages required to build ROS components
+  - if [[ "`uname`" == "Darwin" ]]; then pip3 install catkin_pkg; fi
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user catkin_pkg; fi
+
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip
   - unzip master.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,27 +9,27 @@ environment:
   matrix:
 
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,8 @@ environment:
     #   PROJECT_DIR: examples\catkin
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    - TOOLCHAIN: "dummy"
+
 install:
   # Python 3
   - cmd: set PATH=C:\Python34-x64;C:\Python34-x64\Scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,8 @@ environment:
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "dummy"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,29 +8,31 @@ environment:
 
   matrix:
 
-    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: Python2 needed, as well as empy and catkin_pkg packages to build.
+    #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.12
+    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # 
+    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # 
+    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # 
+    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # 
+    # - TOOLCHAIN: "mingw-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # 
+    # - TOOLCHAIN: "msys-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,33 +10,33 @@ environment:
 
     # FIXME: Python2 needed, as well as empy and catkin_pkg packages to build.
     #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.12
-    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # 
-    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # 
-    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # 
-    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    # 
-    # - TOOLCHAIN: "mingw-cxx17"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    # 
-    # - TOOLCHAIN: "msys-cxx17"
-    #   PROJECT_DIR: examples\catkin
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    - TOOLCHAIN: "dummy"
+    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    
+    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
       PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    
+    - TOOLCHAIN: "mingw-cxx17"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    
+    - TOOLCHAIN: "msys-cxx17"
+      PROJECT_DIR: examples\catkin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    #- TOOLCHAIN: "dummy"
+    #- PROJECT_DIR: examples\catkin
+    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3
@@ -44,6 +44,9 @@ install:
 
   # Install Python package 'requests'
   - cmd: pip install requests
+
+  # Install ROS build dependencies
+  - cmd: pip install empy catkin_pkg
 
   # Install latest Polly toolchains and scripts
   - cmd: appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,35 +8,32 @@ environment:
 
   matrix:
 
-    # FIXME: Python2 needed, as well as empy and catkin_pkg packages to build.
-    #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.12
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
       PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    
+
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
       PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    
+
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
       PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    
+
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
       PROJECT_DIR: examples\catkin
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    
-    - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    
-    - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\catkin
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    #- TOOLCHAIN: "dummy"
-    #- PROJECT_DIR: examples\catkin
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: mingw and msys can't find python package catkin, which could point to some
+    # python paths not being set up correctly after catkin is installed to the cache
+    #  * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.16
+    # - TOOLCHAIN: "mingw-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #
+    # - TOOLCHAIN: "msys-cxx17"
+    #   PROJECT_DIR: examples\catkin
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

Summary as this slightly deviates from the standard instructions:
* There are some build dependencies which are not automatically pulled: python-empy and catkin_pkg (the latter is best to install with pip)

* ROS catkin seems to detect python2 by default and therefore I had to add `python-pip` as well and install `catkin_pkg` with `pip` instead of `pip3`

* OSX builds have trouble using `pip` to install `catkin_pkg` because of a "permission denied" error. Not sure why because almost the same command to install `requests` is not problematic.

* I disabled Windows builds because they seem to not have Python2 at all. ROS officially do not support windows so not sure if it's worth pursuing right now, unless there is general demand from users for ROS windows builds on Hunter. But I don't mind pursuing further if necessary (although I almost never use Windows so I might not be the right person).

* See the links in the diff for the failed builds.

Currently passing tests:
* https://travis-ci.org/lsolanka/hunter/builds/366920389
* https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.14 (dummy toolchain)