### PR TITLE
Add new toolchains to thrift testing tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,11 @@ matrix:
         TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/thrift
 
-    - os: linux
-      env: >
-        TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/thrift
+    # FIXME: https://travis-ci.org/isaachier/hunter/builds/372820536
+    # - os: linux
+    #   env: >
+    #     TOOLCHAIN=analyze-cxx17
+    #     PROJECT_DIR=examples/thrift
 
     - os: linux
       env: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,29 +44,25 @@ matrix:
         TOOLCHAIN=gcc-7-cxx17
         PROJECT_DIR=examples/thrift
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/280841161
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
-    #     PROJECT_DIR=examples/thrift
+    - os: linux
+      env: >
+        TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
+        PROJECT_DIR=examples/thrift
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/280841161
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=analyze-cxx17
-    #     PROJECT_DIR=examples/thrift
+    - os: linux
+      env: >
+        TOOLCHAIN=analyze-cxx17
+        PROJECT_DIR=examples/thrift
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/280841161
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=sanitize-address-cxx17
-    #     PROJECT_DIR=examples/thrift
+    - os: linux
+      env: >
+        TOOLCHAIN=sanitize-address-cxx17
+        PROJECT_DIR=examples/thrift
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/280841161
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=sanitize-leak-cxx17
-    #     PROJECT_DIR=examples/thrift
+    - os: linux
+      env: >
+        TOOLCHAIN=sanitize-leak-cxx17
+        PROJECT_DIR=examples/thrift
 
     - os: linux
       env: >
@@ -89,12 +85,11 @@ matrix:
         TOOLCHAIN=osx-10-13-cxx14
         PROJECT_DIR=examples/thrift
 
-    # FIXME: https://travis-ci.org/isaachier/hunter/builds/280841161
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-    #     PROJECT_DIR=examples/thrift
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+        PROJECT_DIR=examples/thrift
 
     # }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,41 +8,29 @@ environment:
 
   matrix:
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.39
-    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.39
-    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.39
-    # - TOOLCHAIN: "mingw-cxx17"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.39
-    # - TOOLCHAIN: "msys-cxx17"
-    #   PROJECT_DIR: examples\thrift
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    # Extra {
-
-    - TOOLCHAIN: "dummy"
+    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
       PROJECT_DIR: examples\thrift
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # }
+    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\thrift
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\thrift
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      PROJECT_DIR: examples\thrift
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - TOOLCHAIN: "mingw-cxx17"
+      PROJECT_DIR: examples\thrift
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - TOOLCHAIN: "msys-cxx17"
+      PROJECT_DIR: examples\thrift
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,17 +8,20 @@ environment:
 
   matrix:
 
-    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\thrift
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.476
+    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\thrift
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\thrift
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.476
+    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\thrift
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\thrift
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.476
+    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\thrift
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
       PROJECT_DIR: examples\thrift
@@ -28,9 +31,10 @@ environment:
       PROJECT_DIR: examples\thrift
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\thrift
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.476
+    # - TOOLCHAIN: "msys-cxx17"
+    #   PROJECT_DIR: examples\thrift
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **Yes**
