### PR TITLE
Tests for ROS message_generation package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
     packages:
       - python3-pip
       - g++-7
+      - python-pip
+      - python-empy
+      - python-yaml
 
 dist:
   - trusty
@@ -37,37 +40,37 @@ matrix:
     - os: linux
       env: >
         TOOLCHAIN=clang-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=gcc-7-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-address-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-leak-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-thread-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     # }
 
@@ -77,19 +80,19 @@ matrix:
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/ros_message_generation
 
     # }
 
@@ -109,6 +112,10 @@ install:
   # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
   - if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
+
+  # Install python packages required to build ROS components
+  - if [[ "`uname`" == "Darwin" ]]; then pip install --user empy catkin_pkg pyyaml; fi
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,13 +16,15 @@ environment:
       PROJECT_DIR: examples\ros_message_generation
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\ros_message_generation
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\ros_message_generation
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: VS builds fail, for some reason, because path is too long:
+    #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.34
+    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\ros_message_generation
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # 
+    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    #   PROJECT_DIR: examples\ros_message_generation
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     # FIXME: mingw and msys can't find python package catkin, which could point to some
     # python paths not being set up correctly after catkin is installed to the cache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,28 +9,31 @@ environment:
   matrix:
 
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\ros_message_generation
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\ros_message_generation
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\ros_message_generation
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\ros_message_generation
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\foo
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\foo
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: mingw and msys can't find python package catkin, which could point to some
+    # python paths not being set up correctly after catkin is installed to the cache
+    #  * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.16
+    # - TOOLCHAIN: "mingw-cxx17"
+    #   PROJECT_DIR: examples\ros_message_generation
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #
+    # - TOOLCHAIN: "msys-cxx17"
+    #   PROJECT_DIR: examples\ros_message_generation
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3
@@ -38,6 +41,9 @@ install:
 
   # Install Python package 'requests'
   - cmd: pip install requests
+
+  # Install ROS build dependencies
+  - cmd: pip install empy catkin_pkg pyyaml
 
   # Install latest Polly toolchains and scripts
   - cmd: appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

Passing builds:
* https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.35
* https://travis-ci.org/lsolanka/hunter/builds/377460447

For some reason the VS toolchains fail because of this message: https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.34/job/wnecwdaqut5od532#L458
Not sure what's the problem but doesn't seem to be related to the build itself --> too long a file name

So I have commented those toolchains out.
