### PR TITLE
Package ethash: disable ios-nocodesign-11-3-dep-9-3 config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,24 @@ matrix:
         TOOLCHAIN=osx-10-13-cxx14
         PROJECT_DIR=examples/ethash
 
+    # FIXME: https://travis-ci.org/chfast/hunter/jobs/377637356
+    # thead_local not supported by the compiler
+    # - os: osx
+    #   osx_image: xcode9.3
+    #   env: >
+    #     TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+    #     PROJECT_DIR=examples/ethash
+
     - os: osx
       osx_image: xcode9.3
       env: >
-        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3-arm64
+        PROJECT_DIR=examples/ethash
+
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3-armv7
         PROJECT_DIR=examples/ethash
 
     # }


### PR DESCRIPTION
<!--- Please check that your pull request satisfy all requirements -->

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**

