### PR TITLE
Tests for rospack package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,12 @@ matrix:
         TOOLCHAIN=gcc-7-cxx17
         PROJECT_DIR=examples/rospack
 
-    - os: linux
-      env: >
-        TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/rospack
+    # FIXME: Cannot find PythonLibs:
+    #   * https://travis-ci.org/lsolanka/hunter/jobs/377495853 
+    # - os: linux
+    #   env: >
+    #     TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
+    #     PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,11 +88,14 @@ matrix:
         TOOLCHAIN=osx-10-13-cxx14
         PROJECT_DIR=examples/rospack
 
-    - os: osx
-      osx_image: xcode9.3
-      env: >
-        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/rospack
+    # FIXME: ios toolchain not building due to missing install parameters:
+    #   * https://travis-ci.org/lsolanka/hunter/jobs/377479349
+    #  Most likely just needs to be added to CMakeLists.txt
+    #  - os: osx
+    #    osx_image: xcode9.3
+    #    env: >
+    #      TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+    #      PROJECT_DIR=examples/rospack
 
     # }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ addons:
     packages:
       - python3-pip
       - g++-7
+      - python-pip
+      - python-empy
+      - python-yaml
 
 dist:
   - trusty
@@ -36,37 +39,37 @@ matrix:
     - os: linux
       env: >
         TOOLCHAIN=clang-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=gcc-7-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-address-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-leak-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: linux
       env: >
         TOOLCHAIN=sanitize-thread-cxx17
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     # }
 
@@ -76,19 +79,19 @@ matrix:
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-make-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=osx-10-13-cxx14
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     - os: osx
       osx_image: xcode9.3
       env: >
         TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/foo
+        PROJECT_DIR=examples/rospack
 
     # }
 
@@ -108,6 +111,10 @@ install:
   # 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
   - if [[ "`uname`" == "Darwin" ]]; then pip3 install requests; fi
   - if [[ "`uname`" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
+
+  # Install python packages required to build ROS components
+  - if [[ "`uname`" == "Darwin" ]]; then pip install --user empy catkin_pkg pyyaml; fi
+  - if [[ "`uname`" == "Linux" ]]; then travis_retry pip install --user catkin_pkg; fi
 
   # Install latest Polly toolchains and scripts
   - wget https://github.com/ruslo/polly/archive/master.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     packages:
       - python3-pip
       - g++-7
+      - python-dev
       - python-pip
       - python-empy
       - python-yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,28 +9,31 @@ environment:
   matrix:
 
     - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\rospack
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\rospack
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\rospack
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\foo
+      PROJECT_DIR: examples\rospack
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\foo
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    - TOOLCHAIN: "msys-cxx17"
-      PROJECT_DIR: examples\foo
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: mingw and msys can't find python package catkin, which could point to some
+    # python paths not being set up correctly after catkin is installed to the cache
+    #  * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.16
+    # - TOOLCHAIN: "mingw-cxx17"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #
+    # - TOOLCHAIN: "msys-cxx17"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3
@@ -38,6 +41,9 @@ install:
 
   # Install Python package 'requests'
   - cmd: pip install requests
+
+  # Install ROS build dependencies
+  - cmd: pip install empy catkin_pkg pyyaml
 
   # Install latest Polly toolchains and scripts
   - cmd: appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,21 +8,25 @@ environment:
 
   matrix:
 
-    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\rospack
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # FIXME: Boost does not build with these toolchains:
+    #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.36
+    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #
+    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\rospack
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-      PROJECT_DIR: examples\rospack
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\rospack
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # FIXME: An issue with linking agains TinyXML2 in VS:
+    #   * https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.36
+    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    #
+    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    #   PROJECT_DIR: examples\rospack
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     # FIXME: mingw and msys can't find python package catkin, which could point to some
     # python paths not being set up correctly after catkin is installed to the cache
@@ -34,6 +38,10 @@ environment:
     # - TOOLCHAIN: "msys-cxx17"
     #   PROJECT_DIR: examples\rospack
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - TOOLCHAIN: "dummy"
+      PROJECT_DIR: examples\rospack
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3


### PR DESCRIPTION
* I have checked that this pull request contains only `.travis.yml`/`appveyor.yml` changes. All other changes send to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented out instead so other developers can enable them back easily and to simplify merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the broken CI build page or to the minimum compiler requirements documentation so other developers can figure out what was the problem exactly. **Yes**

* Windows builds had to be disabled completely (dummy toolchain): either boost doesn't build or there are issues linking against TinyXML2.

Passing builds:
* https://ci.appveyor.com/project/lsolanka/hunter/build/1.0.38 (dummy toolchain)
* https://travis-ci.org/lsolanka/hunter/builds/378055969