### PR TITLE
pr.pkg.harfbuzz - remove broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,12 @@ matrix:
         TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/harfbuzz
 
-    - os: linux
-      env: >
-        TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/harfbuzz
+    # fails seemingly because of harmless warnings
+    # https://travis-ci.com/jhs67/hunter/jobs/124660703
+    #- os: linux
+    #  env: >
+    #    TOOLCHAIN=analyze-cxx17
+    #    PROJECT_DIR=examples/harfbuzz
 
     - os: linux
       env: >
@@ -85,11 +87,13 @@ matrix:
         TOOLCHAIN=osx-10-13-cxx14
         PROJECT_DIR=examples/harfbuzz
 
-    - os: osx
-      osx_image: xcode9.3
-      env: >
-        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-        PROJECT_DIR=examples/harfbuzz
+    # FIXME: fails without an obvious error - maybe times out
+    # https://travis-ci.com/jhs67/hunter/jobs/124660709
+    #- os: osx
+    #  osx_image: xcode9.3
+    #  env: >
+    #    TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+    #    PROJECT_DIR=examples/harfbuzz
 
     # }
 


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. YES

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. YES

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. YES

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. Maybe - I ran the tests?

I previously created a pull request but some of the packages are broken - now commented out.
