### PR TITLE
 Re-enabled fixed toolchains after tacopie 3.2.0 update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,15 @@ matrix:
   include:
     # Linux {
 
-    # FIXME: https://travis-ci.org/ingenue/hunter/jobs/382339170
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=clang-cxx17
-    #     PROJECT_DIR=examples/tacopie
+    - os: linux
+      env: >
+        TOOLCHAIN=clang-cxx17
+        PROJECT_DIR=examples/tacopie
 
-    # FIXME: https://travis-ci.org/ingenue/hunter/jobs/382339171
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=gcc-7-cxx17
-    #     PROJECT_DIR=examples/tacopie
+    - os: linux
+      env: >
+        TOOLCHAIN=gcc-7-cxx17
+        PROJECT_DIR=examples/tacopie
 
     # FIXME: fails on "ld: cannot find -lpthread"
     # - os: linux
@@ -57,23 +55,20 @@ matrix:
     #     TOOLCHAIN=analyze-cxx17
     #     PROJECT_DIR=examples/tacopie
 
-    # FIXME: https://travis-ci.org/ingenue/hunter/jobs/382339172
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=sanitize-address-cxx17
-    #     PROJECT_DIR=examples/tacopie
+    - os: linux
+      env: >
+        TOOLCHAIN=sanitize-address-cxx17
+        PROJECT_DIR=examples/tacopie
 
-    # FIXME: https://travis-ci.org/ingenue/hunter/jobs/382339173
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=sanitize-leak-cxx17
-    #     PROJECT_DIR=examples/tacopie
+    - os: linux
+      env: >
+        TOOLCHAIN=sanitize-leak-cxx17
+        PROJECT_DIR=examples/tacopie
 
-    # FIXME: https://travis-ci.org/ingenue/hunter/jobs/382339174
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=sanitize-thread-cxx17
-    #     PROJECT_DIR=examples/tacopie
+    - os: linux
+      env: >
+        TOOLCHAIN=sanitize-thread-cxx17
+        PROJECT_DIR=examples/tacopie
 
     # }
 
@@ -85,19 +80,17 @@ matrix:
         TOOLCHAIN=osx-10-13-make-cxx14
         PROJECT_DIR=examples/tacopie
 
-    # FIXME: all below tests fail with job errored
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=osx-10-13-cxx14
-    #     PROJECT_DIR=examples/tacopie
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=osx-10-13-cxx14
+        PROJECT_DIR=examples/tacopie
 
-    # FIXME: all below tests fail with job errored
-    # - os: osx
-    #   osx_image: xcode9.3
-    #   env: >
-    #     TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
-    #     PROJECT_DIR=examples/tacopie
+    - os: osx
+      osx_image: xcode9.3
+      env: >
+        TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
+        PROJECT_DIR=examples/tacopie
 
     # }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,14 @@ matrix:
         PROJECT_DIR=examples/tacopie
 
     # FIXME: fails on "ld: cannot find -lpthread"
+    # https://travis-ci.org/szatan/hunter/jobs/382163759
     # - os: linux
     #   env: >
     #     TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
     #     PROJECT_DIR=examples/tacopie
 
     # FIXME
+    # https://travis-ci.org/szatan/hunter/jobs/382163760
     # - os: linux
     #   env: >
     #     TOOLCHAIN=analyze-cxx17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,13 +16,13 @@ environment:
       PROJECT_DIR: examples\tacopie
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\tacopie
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\tacopie
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-    #   PROJECT_DIR: examples\tacopie
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      PROJECT_DIR: examples\tacopie
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     # - TOOLCHAIN: "mingw-cxx17"
     #   PROJECT_DIR: examples\tacopie

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,14 @@ environment:
       PROJECT_DIR: examples\tacopie
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    # FIXME
+    # https://ci.appveyor.com/project/szatan/hunter/build/1.0.6/job/yn3dxtaf86ufvtu1
     # - TOOLCHAIN: "mingw-cxx17"
     #   PROJECT_DIR: examples\tacopie
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    # FIXME
+    # https://ci.appveyor.com/project/szatan/hunter/build/1.0.6/job/5r6rx8nmkq7s5sxs
     # - TOOLCHAIN: "msys-cxx17"
     #   PROJECT_DIR: examples\tacopie
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **[Yes]**
