### PR TITLE
change ios build to VERBOSE=0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ matrix:
       env: >
         TOOLCHAIN=ios-nocodesign-11-3-dep-9-3
         PROJECT_DIR=examples/glm
+        VERBOSE=0
 
     # }
 


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. Yes

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. Yes

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. N/A

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. Yes
