### PR TITLE
enables broken ci builds again for pkg.glbinding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,11 @@ matrix:
         TOOLCHAIN=gcc-7-cxx17
         PROJECT_DIR=examples/glbinding
 
-    # FIXME android build is broken with the current glbinding version
-    # https://travis-ci.org/ingenue/hunter/builds/448761375?utm_source=github_status&utm_medium=notification
-    # - os: linux
-    #  env: >
-    #    TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
-    #    PROJECT_DIR=examples/glbinding
-    #
+    - os: linux
+      env: >
+        TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
+        PROJECT_DIR=examples/glbinding
+
     - os: linux
       env: >
         TOOLCHAIN=analyze-cxx17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,9 @@ environment:
       PROJECT_DIR: examples\glbinding
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    # FIXME build is broken with current glbinding version
-    # - TOOLCHAIN: "msys-cxx17"
-    #  PROJECT_DIR: examples\glbinding
-    #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLCHAIN: "msys-cxx17"
+      PROJECT_DIR: examples\glbinding
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Python 3


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

https://travis-ci.org/tnixeu/hunter/builds/448852785
https://ci.appveyor.com/project/tnixeu/hunter/builds/19944806

The iOS build for iOS is still disabled.
