### PR TITLE
Remove analyzer build from lodepng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,12 @@ matrix:
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/LodePNG
 
-    - os: linux
-      env: >
-        TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/LodePNG
+    # FIXME: Clang static analyzer build is not supported by this package
+    # * https://travis-ci.com/bkotzz/hunter/jobs/162084297
+    # - os: linux
+    #   env: >
+    #     TOOLCHAIN=analyze-cxx17
+    #     PROJECT_DIR=examples/LodePNG
 
     - os: linux
       env: >


### PR DESCRIPTION
<!--- Please check that your pull request satisfy all requirements -->

I am working on adding the LodePNG package, but I did not understand how to run CI when I first changed the travis/appveyor files. I've now run CI on my fork, and the only build failing is the clang analyzer one. I've commented it out here with the link to the broken build.

Build links before this change:
- https://travis-ci.com/bkotzz/hunter/builds/93198200
- https://ci.appveyor.com/project/bkotzz/hunter/builds/20685654

Build links after this change:
- https://travis-ci.com/bkotzz/hunter/builds/93455737
- https://ci.appveyor.com/project/bkotzz/hunter/builds/20747808

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**
