### PR TITLE
Enable analyze-cxx17 for 'intx' package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,10 @@ matrix:
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/intx
 
-    # FIXME: The clang analyzer reports warnings.
-    # https://travis-ci.org/chfast/hunter/jobs/525003020
-    # - os: linux
-    #   env: >
-    #     TOOLCHAIN=analyze-cxx17
-    #     PROJECT_DIR=examples/intx
+    - os: linux
+      env: >
+        TOOLCHAIN=analyze-cxx17
+        PROJECT_DIR=examples/intx
 
     - os: linux
       env: >


### PR DESCRIPTION
This build configuration was fixed in intx 0.2

The test build: https://travis-ci.org/chfast/hunter/builds/532706213

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes or commits merged from the `pkg.template` branch. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**

