### PR TITLE
Enable Windows builds fixed in leveldb 1.22

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,43 +8,30 @@ environment:
 
   matrix:
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.300
-    # - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\leveldb
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLCHAIN: "ninja-vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\leveldb
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.300
-    # - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\leveldb
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLCHAIN: "nmake-vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\leveldb
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.300
-    # - TOOLCHAIN: "vs-15-2017-win64-cxx17"
-    #   PROJECT_DIR: examples\leveldb
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      PROJECT_DIR: examples\leveldb
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.300
-    # - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-    #   PROJECT_DIR: examples\leveldb
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      PROJECT_DIR: examples\leveldb
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    # FIXME: https://ci.appveyor.com/project/isaachier/hunter/build/1.0.300
-    # - TOOLCHAIN: "mingw-cxx17"
-    #   PROJECT_DIR: examples\leveldb
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLCHAIN: "mingw-cxx17"
+      PROJECT_DIR: examples\leveldb
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     # FIXME: https://ci.appveyor.com/project/chfast/hunter/builds/24865453/job/hv4dkufehvjrl8g4
     # - TOOLCHAIN: "msys-cxx17"
     #   PROJECT_DIR: examples\leveldb
     #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    # Extra {
-
-    - TOOLCHAIN: "dummy"
-      PROJECT_DIR: examples\leveldb
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
-    # }
 
 install:
   # Python 3


### PR DESCRIPTION
<!--- Please check that your pull request satisfy all requirements -->

* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes or commits merged from the `pkg.template` branch. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**
     - https://ci.appveyor.com/project/chfast/hunter/builds/24890065

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**
