### PR TITLE
Disable verbose logging for analyze-cxx17 toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ matrix:
       env: >
         TOOLCHAIN=analyze-cxx17
         PROJECT_DIR=examples/ros_common_msgs
+        VERBOSE=0
 
     - os: linux
       env: >


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes or commits merged from the `pkg.template` branch. All other changes send
  to https://github.com/ruslo/hunter. **[Yes]**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **[Yes]**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **[Yes]**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **[Yes]**

Prior to this change, the analyze-cxx17 toolchain for package `ros_common_msgs` was failing due to too long a log - https://travis-ci.com/kgeorgiev93/hunter/builds/114179961.

With this change, this toolchain successfully builds - https://travis-ci.com/kgeorgiev93/hunter/builds/114243054.

This change is part of the update of ros_common_msgs, which is done in this pull request - https://github.com/ruslo/hunter/pull/1892
