### PR TITLE
libigl: Exclude broken toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,11 @@ matrix:
         TOOLCHAIN=android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
         PROJECT_DIR=examples/libigl
 
-    - os: linux
-      env: >
-        TOOLCHAIN=analyze-cxx17
-        PROJECT_DIR=examples/libigl
+    #FIXME: https://travis-ci.com/rbsheth/hunter/jobs/210909062
+    #- os: linux
+    #  env: >
+    #    TOOLCHAIN=analyze-cxx17
+    #    PROJECT_DIR=examples/libigl
 
     - os: linux
       env: >
@@ -84,11 +85,12 @@ matrix:
         TOOLCHAIN=osx-10-13-cxx14
         PROJECT_DIR=examples/libigl
 
-    - os: osx
-      osx_image: xcode9.4
-      env: >
-        TOOLCHAIN=ios-nocodesign-11-4-dep-9-3
-        PROJECT_DIR=examples/libigl
+    #FIXME: https://travis-ci.com/rbsheth/hunter/jobs/210909068
+    #- os: osx
+    #  osx_image: xcode9.4
+    #  env: >
+    #    TOOLCHAIN=ios-nocodesign-11-4-dep-9-3
+    #    PROJECT_DIR=examples/libigl
 
     # }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,15 @@ environment:
       PROJECT_DIR: examples\libigl
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
-      PROJECT_DIR: examples\libigl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #FIXME: https://ci.appveyor.com/project/rbsheth/hunter/builds/25537275/job/1sq7fvw69v8ywvb9
+    #- TOOLCHAIN: "vs-14-2015-sdk-8-1"
+    #  PROJECT_DIR: examples\libigl
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - TOOLCHAIN: "mingw-cxx17"
-      PROJECT_DIR: examples\libigl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #FIXME: https://ci.appveyor.com/project/rbsheth/hunter/builds/25537275/job/fagmjs7t0tun83a3
+    #- TOOLCHAIN: "mingw-cxx17"
+    #  PROJECT_DIR: examples\libigl
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - TOOLCHAIN: "msys-cxx17"
       PROJECT_DIR: examples\libigl


### PR DESCRIPTION
* I have checked that this pull request contains only
  `.travis.yml`/`appveyor.yml` changes or commits merged from the `pkg.template` branch. All other changes send
  to https://github.com/ruslo/hunter. **Yes**

* I have checked that no toolchains removed from CI configs, they are commented
  out instead so other developers can enable them back easily and to simplify
  merge conflict resolution. **Yes**

* I have checked that for every commented out toolchain there is a link to the
  broken CI build page or to the minimum compiler requirements documentation
  so other developers can figure out what was the problem exactly. **Yes**

* I have checked that for every enabled toolchain corresponding package passed
  all stages of update cycle: test/merge/upload/release. **Yes**

@ruslo 
