### PR TITLE
add python3-setuptools to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - python3-pip
+      - python3-setuptools
       - g++-7
 
 dist:


### PR DESCRIPTION
My jobs were failing to install packages because of missing setuptools: https://travis-ci.org/wheybags/hunter/jobs/561765102